### PR TITLE
Default fonts caused error because they could not be found in the fonts folder

### DIFF
--- a/stubs/ibis.php
+++ b/stubs/ibis.php
@@ -15,10 +15,7 @@ return [
     /**
      * The list of fonts to be used in the different themes.
      */
-    'fonts' => [
-        'calibri' => 'Calibri-Regular.ttf',
-        'times' => 'times-regular.ttf',
-    ],
+    'fonts' => [],
 
     /**
      * Page ranges to be used with the sample command.


### PR DESCRIPTION
In the stubs, u had Calibri and Times TTF set but none was shipped in the fonts folder. It causes immediate error when you try your first build.

I removed the defaults fonts in the config file (ibis.php). User experience is now safe : you build your book and IF YOU WANT other fonts, u can read documentation on the github page and go forward.