### PR TITLE
Add reference to gd extension in php.ini

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Ibis was used to create [Laravel Queues in Action](https://learn-laravel-queues.
 
 ## Installation
 
-Make sure you have PHP7.3 or above installed on your system.
+Make sure you have PHP7.3 or above installed on your system and that your gd extension is enabled in your php.ini file.
 
 First, install the composer package globally:
 


### PR DESCRIPTION
Without this extension enabled, you see this error:

```
  Problem 1
    - mpdf/mpdf[v8.0.0, ..., v8.0.3] require php ^5.6 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 -> your php version (7.4.4) does not satisfy that requirement.
    - mpdf/mpdf[v8.0.4, ..., v8.0.7] require ext-gd * -> it is missing from your system. Install or enable PHP's gd extension.
```

To resolve, alter your php.ini to reflect something like this:

```
extension=gd2
```