### PR TITLE
feat: configurable table of contents levels

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -196,9 +196,7 @@ class BuildCommand extends Command
 
         $pdf->setAutoBottomMargin = 'pad';
 
-        $tocLevels = [
-            'H1' => 0, 'H2' => 1
-        ];
+        $tocLevels = $config['toc_levels'];
 
         $pdf->h2toc = $tocLevels;
         $pdf->h2bookmarks = $tocLevels;
@@ -224,7 +222,7 @@ HTML
             $this->output->writeln('<fg=yellow>==></> Adding Book Cover ...');
 
             $cover = $this->disk->get($currentPath . '/assets/cover.html');
-            
+
             $pdf->WriteHTML($cover);
 
             $pdf->AddPage();

--- a/stubs/ibis.php
+++ b/stubs/ibis.php
@@ -33,6 +33,14 @@ return [
         'margin_top' => 14,
     ],
 
+    /**
+     * Table of Contents Levels
+     */
+    'toc_levels' => [
+        'H1' => 0,
+        'H2' => 1,
+    ],
+
 
     /**
      * Cover photo position and dimensions
@@ -49,13 +57,13 @@ return [
     'sample' => [
         [1, 3],
         [80, 85],
-        [100, 103]
+        [100, 103],
     ],
 
 
     /**
      * A notice printed at the final page of a generated sample.
      */
-    'sample_notice' => 'This is a sample from "Laravel Queues in Action" by Mohamed Said. <br> 
+    'sample_notice' => 'This is a sample from "Laravel Queues in Action" by Mohamed Said. <br>
                         For more information, <a href="https://www.learn-laravel-queues.com/">Click here</a>.',
 ];


### PR DESCRIPTION
Add table of contents levels option in `ibis.php`.

Allows users to add `H3`, `H…` to the table of contents.